### PR TITLE
feature/init agent

### DIFF
--- a/src/cmd_init_agent.zig
+++ b/src/cmd_init_agent.zig
@@ -11,7 +11,7 @@ pub fn cmdInitAgent(allocator: std.mem.Allocator, args_iter: *platform_mod.ArgIt
         \\**Drop-in replacement for `git`.** Use `ziggit` exactly like `git` for all operations.
         \\
         \\## Notice for AI Agents
-        \\- **Succinct Mode:** Output is heavily compressed by default to save tokens. If you need standard verbose output to understand a complex state, use `ziggit --no-succinct <cmd>`.
+        \\- **Succinct Mode:** Output is heavily compressed by default to save tokens. If you need standard verbose output to understand a complex state, use `GIT_SUCCINCT=0 GIT_TRACE=1 ZIGGIT_TRACE_TIMING=1 ziggit <cmd>`.
         \\
         \\## Workflow Commands
         \\Convenient aliases for development loops:

--- a/src/cmd_init_agent.zig
+++ b/src/cmd_init_agent.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const platform_mod = @import("platform/platform.zig");
+const helpers = @import("git_helpers.zig");
+
+pub fn cmdInitAgent(allocator: std.mem.Allocator, args_iter: *platform_mod.ArgIterator, platform_impl: *const platform_mod.Platform) !void {
+    _ = args_iter; // No additional arguments expected for now
+
+    const ziggit_md_content =
+        \\# ziggit
+        \\
+        \\**Drop-in replacement for `git`.** Use `ziggit` exactly like `git` for all operations.
+        \\
+        \\## Notice for AI Agents
+        \\- **Succinct Mode:** Output is heavily compressed by default to save tokens. If you need standard verbose output to understand a complex state, use `ziggit --no-succinct <cmd>`.
+        \\
+        \\## Workflow Commands
+        \\Convenient aliases for development loops:
+        \\- `ziggit restart` : `fetch` + `rebase` onto `origin/main`
+        \\- `ziggit start` : `stash` + `restart` + `pop` (safe restart with dirty tree)
+        \\- `ziggit progress "msg"` : `add -A` + `commit` + `push` + `restart`
+        \\
+        \\## Verification
+        \\- `ziggit --version-info`
+        \\
+        \\Refer to CLAUDE.md for full command reference.
+    ;
+
+    // 1. Create ziggit.md in the current directory
+    try std.fs.cwd().writeFile(.{ .sub_path = "ziggit.md", .data = ziggit_md_content });
+    try platform_impl.writeStdout("Created ziggit.md\n");
+
+    // 2. Append "@ziggit.md" to ~/.claude/CLAUDE.md
+    const home_dir = std.process.getEnvVarOwned(allocator, "HOME") catch {
+        try platform_impl.writeStderr("Error: HOME environment variable not found.\n");
+        return;
+    };
+    defer allocator.free(home_dir);
+
+    const claude_md_path = try std.fs.path.join(allocator, &.{ home_dir, ".claude", "CLAUDE.md" });
+    defer allocator.free(claude_md_path);
+
+    // Check if ~/.claude exists, if not, create it
+    const claude_dir_path = try std.fs.path.join(allocator, &.{ home_dir, ".claude" });
+    defer allocator.free(claude_dir_path);
+    std.fs.makeDirAbsolute(claude_dir_path) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+
+    // Open CLAUDE.md in read/write mode, or create it if it doesn't exist
+    var file = try std.fs.createFileAbsolute(claude_md_path, .{ .read = true, .truncate = false });
+    defer file.close();
+
+    // Check if it already contains @ziggit.md
+    const stat = try file.stat();
+    if (stat.size > 0) {
+        // Read file content to check for existing reference
+        try file.seekTo(0);
+        const content = try file.readToEndAlloc(allocator, 1024 * 1024); // max 1MB
+        defer allocator.free(content);
+        
+        if (std.mem.indexOf(u8, content, "@ziggit.md") != null) {
+            try platform_impl.writeStdout("~/.claude/CLAUDE.md already contains @ziggit.md\n");
+            return;
+        }
+
+        // Seek to end to append
+        try file.seekFromEnd(0);
+        if (content[content.len - 1] != '\n') {
+            try file.writeAll("\n");
+        }
+    }
+
+    try file.writeAll("@ziggit.md\n");
+    try platform_impl.writeStdout("Appended \"@ziggit.md\" to ~/.claude/CLAUDE.md\n");
+}

--- a/src/git_helpers.zig
+++ b/src/git_helpers.zig
@@ -222,9 +222,8 @@ const NATIVE_COMMANDS = [_][]const u8{
     "grep", "notes", "format-patch", "whatchanged", "for-each-repo", "bugreport", "diagnose",
     "web--browse", "fast-import", "fast-export", "pack-refs",
     "shortlog", "credential",
-    "restart", "start", "progress",
-};
-
+    "restart", "start", "progress", "init-agent",
+    };
 
 pub fn isNativeCommand(command: []const u8) bool {
     if (std.mem.startsWith(u8, command, "--list-cmds=")) return true;

--- a/src/main_common.zig
+++ b/src/main_common.zig
@@ -40,6 +40,7 @@ const cmd_fsck = @import("cmd_fsck.zig");
 const cmd_gc = @import("cmd_gc.zig");
 const cmd_hash_object = @import("cmd_hash_object.zig");
 const cmd_init = @import("cmd_init.zig");
+const cmd_init_agent = @import("cmd_init_agent.zig");
 const cmd_last_modified = @import("cmd_last_modified.zig");
 const cmd_log = @import("cmd_log.zig");
 const cmd_shortlog = @import("cmd_shortlog.zig");
@@ -840,6 +841,7 @@ pub fn zigzitMain(allocator: std.mem.Allocator) !void {
     // against crashes when no git directory exists (e.g. `git init`, `git --version`).
     const skip_preconfig = std.mem.eql(u8, command, "init") or
         std.mem.eql(u8, command, "init-db") or
+        std.mem.eql(u8, command, "init-agent") or
         std.mem.eql(u8, command, "clone") or
         std.mem.eql(u8, command, "--version") or
         std.mem.eql(u8, command, "-v") or
@@ -863,6 +865,8 @@ pub fn zigzitMain(allocator: std.mem.Allocator) !void {
             if (std.mem.eql(u8, ga, "--bare")) global_bare = true;
         }
         try cmd_init.cmdInit(allocator, &args_iter, &platform_impl, global_bare);
+    } else if (std.mem.eql(u8, command, "init-agent")) {
+        try cmd_init_agent.cmdInitAgent(allocator, &args_iter, &platform_impl);
     } else if (std.mem.eql(u8, command, "status")) {
         const status_alloc = if (comptime @import("builtin").target.os.tag != .freestanding and @import("builtin").target.os.tag != .wasi) std.heap.c_allocator else allocator;
         try cmd_status.cmdStatus(status_alloc, &args_iter, &platform_impl, all_original_args.items);

--- a/test/cli_init_agent_test.sh
+++ b/test/cli_init_agent_test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# test/cli_init_agent_test.sh - Test init-agent subcommand
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ZIGGIT="${ZIGGIT:-$SCRIPT_DIR/../zig-out/bin/ziggit}"
+PASS=0
+FAIL=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ✗ FAIL: $1"; FAIL=$((FAIL+1)); }
+
+if [ ! -x "$ZIGGIT" ]; then
+    echo "Building ziggit..."
+    (cd "$SCRIPT_DIR/.." && zig build 2>/dev/null) || { echo "Build failed"; exit 1; }
+fi
+
+TMPDIR=$(mktemp -d /tmp/ziggit_cli_init_agent_test.XXXXXX)
+trap "rm -rf $TMPDIR" EXIT
+
+# Mock HOME so we don't modify the real ~/.claude/CLAUDE.md
+export HOME="$TMPDIR/fake_home"
+mkdir -p "$HOME"
+
+echo "=== CLI init-agent Tests ==="
+
+# ---- Test 1: First run creates ziggit.md and appends to CLAUDE.md ----
+echo "Test 1: First run"
+mkdir -p "$TMPDIR/t1"
+(cd "$TMPDIR/t1" && $ZIGGIT init-agent)
+
+if [ -f "$TMPDIR/t1/ziggit.md" ]; then
+    pass "ziggit.md created"
+else
+    fail "ziggit.md created"
+fi
+
+if [ -f "$HOME/.claude/CLAUDE.md" ]; then
+    pass "CLAUDE.md created"
+else
+    fail "CLAUDE.md created"
+fi
+
+if grep -q "@ziggit.md" "$HOME/.claude/CLAUDE.md"; then
+    pass "@ziggit.md appended to CLAUDE.md"
+else
+    fail "@ziggit.md appended to CLAUDE.md"
+fi
+
+# ---- Test 2: Second run does not append duplicate @ziggit.md ----
+echo "Test 2: Second run (idempotency)"
+# Run it again in the same directory
+(cd "$TMPDIR/t1" && $ZIGGIT init-agent)
+
+COUNT=$(grep -c "@ziggit.md" "$HOME/.claude/CLAUDE.md" || true)
+if [ "$COUNT" -eq 1 ]; then
+    pass "Only one @ziggit.md in CLAUDE.md"
+else
+    fail "Duplicate @ziggit.md found in CLAUDE.md (count=$COUNT)"
+fi
+
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Design

This PR introduces the `init-agent` subcommand to `ziggit`. Its primary design goal is to facilitate seamless integration with AI agents (like Claude) by providing them with necessary workspace context about `ziggit` being a drop-in replacement for `git`.

When executed, `init-agent` performs two main actions:
1. **Creates `ziggit.md`**: Generates a context file in the current directory containing instructions for AI agents on how to use `ziggit` (e.g., handling succinct mode, workflow commands).
2. **Updates `CLAUDE.md`**: Appends a reference to `@ziggit.md` in the user's global `~/.claude/CLAUDE.md` file, ensuring the agent automatically picks up this context.

## Issues Discovered and Fixed During Review

During the review and testing of this branch, several issues in the initial implementation were identified and resolved:

1. **Idempotency**: The original implementation blindly appended `@ziggit.md` to `CLAUDE.md` on every run. This was fixed by reading the file first and only appending if the reference doesn't already exist.
2. **Execution Outside Git Repository**: The command failed if run outside a valid git repository because of pre-command config validation. `init-agent` was added to the `skip_preconfig` list in `src/main_common.zig` to allow it to run anywhere.
3. **Command Fallback**: The command was not recognized as a native command and incorrectly fell back to the system's `git` binary. This was fixed by adding `init-agent` to the `NATIVE_COMMANDS` list in `src/git_helpers.zig`.
4. **Test Coverage**: Added a comprehensive shell integration test (`test/cli_init_agent_test.sh`) that mocks the `HOME` directory to safely verify both the initial creation and the idempotency of the command.
